### PR TITLE
fix: address feedback and simplify API

### DIFF
--- a/crates/core/src/gas.rs
+++ b/crates/core/src/gas.rs
@@ -1,8 +1,8 @@
 use regex::Regex;
 use std::num::ParseIntError;
 
-pub fn parse_str(from: &str) -> Option<String> {
-    let gas = Regex::new(r"(?:gas)\s*")
+fn parse_str(from: &str) -> Option<String> {
+    let gas = Regex::new(r"(?i:gas)\s*")
         .unwrap()
         .replace_all(from, "")
         .to_string();

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,4 @@
 pub mod gas;
 pub mod near;
-pub mod parse;
 pub mod prefixes;
-pub mod unit;
 pub mod util;

--- a/crates/core/src/near.rs
+++ b/crates/core/src/near.rs
@@ -2,7 +2,7 @@ use std::num::ParseIntError;
 
 use regex::Regex;
 
-pub fn parse_str(input: &str) -> Option<String> {
+fn parse_str(input: &str) -> Option<String> {
     let near = Regex::new(r"(?i:n(?i:ear)?)\s*$")
         .unwrap()
         .replace_all(input, "")

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -1,8 +1,0 @@
-use std::num::ParseIntError;
-
-use crate::gas;
-use crate::near;
-
-pub fn parse(input: &str) -> Result<u128, ParseIntError> {
-    near::parse(input).or_else(|_| gas::parse(input))
-}

--- a/crates/core/src/prefixes.rs
+++ b/crates/core/src/prefixes.rs
@@ -27,7 +27,7 @@ pub static MAGNITUDES: [i8; 20] = [
     24, 21, 18, 15, 12, 9, 6, 3, 2, 1, -1, -2, -3, -6, -9, -12, -15, -18, -21, -24,
 ];
 
-pub fn from_magnitude(magnitude: i8) -> Option<&'static str> {
+pub const fn from_magnitude(magnitude: i8) -> Option<&'static str> {
     match magnitude {
         24 => Some("Y"),
         21 => Some("Z"),

--- a/crates/core/src/unit.rs
+++ b/crates/core/src/unit.rs
@@ -1,9 +1,0 @@
-use std::num::ParseIntError;
-
-pub trait ParseableUnit {
-    fn parse(input: &str) -> Option<String>;
-
-    fn parse_u128(input: &str) -> Result<u128, ParseIntError>;
-
-    fn human(input: &u128) -> String;
-}

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -17,6 +17,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0"
-syn = {version = "=1.0.78", features = ["full", "fold", "extra-traits"] }
+syn = {version = "1", features = ["full", "fold", "extra-traits"] }
 quote = "1.0"
-near-units-core = "0.1.0"
+
+near-units-core = { path = "../core", version = "0.1.0" }

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -1,17 +1,21 @@
 extern crate proc_macro;
+use std::num::ParseIntError;
+
 use near_units_core::{gas, near};
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
 use syn::{ExprLit, Lit};
 
-#[proc_macro]
-pub fn parse_near(item: TokenStream) -> TokenStream {
+fn parse_knobs<F>(item: TokenStream, parse: F) -> TokenStream
+where
+    F: FnOnce(&str) -> Result<u128, ParseIntError>,
+{
     match syn::parse::<ExprLit>(item) {
         Ok(ExprLit {
             lit: Lit::Str(str), ..
         }) => {
-            let str = near::parse(&str.value()).unwrap();
+            let str = parse(&str.value()).unwrap();
             TokenStream::from(quote! {#str})
         }
         _ => TokenStream::from(
@@ -25,20 +29,11 @@ pub fn parse_near(item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
+pub fn parse_near(item: TokenStream) -> TokenStream {
+    parse_knobs(item, near::parse)
+}
+
+#[proc_macro]
 pub fn parse_gas(item: TokenStream) -> TokenStream {
-    match syn::parse::<ExprLit>(item) {
-        Ok(ExprLit {
-            lit: Lit::Str(str), ..
-        }) => {
-            let str = gas::parse(&str.value()).unwrap();
-            TokenStream::from(quote! {#str})
-        }
-        _ => TokenStream::from(
-            syn::Error::new(
-                Span::call_site(),
-                "parse can only be used with string literals",
-            )
-            .to_compile_error(),
-        ),
-    }
+    parse_knobs(item, |x| gas::parse(x))
 }

--- a/crates/units/Cargo.toml
+++ b/crates/units/Cargo.toml
@@ -14,5 +14,5 @@ Rust library for parsing and displaying NEAR units.
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-near-units-core = "0.1.0"
-near-units-macro = "0.1.0"
+near-units-core = { path = "../core", version = "0.1.0"}
+near-units-macro = { path = "../macro", version = "0.1.0"}

--- a/crates/units/src/lib.rs
+++ b/crates/units/src/lib.rs
@@ -1,15 +1,25 @@
 pub use near_units_core::*;
 pub use near_units_macro::*;
 
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    const ONE_NEAR: u128 = parse_near!("1N");
-    const ONE_TGAS: u128 = parse_gas!("1 TGas");
+    const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
+    const ONE_TGAS: u128 = 1_000_000_000_000;
+    const ONE_PARSED_NEAR: u128 = parse_near!("1 N");
+    const ONE_PARSED_TGAS: u128 = parse_gas! ("1 TGas");
 
     #[test]
-    fn const_parse_works() {
+    fn const_parse_near() {
         assert_eq!(near::parse("1N").unwrap(), ONE_NEAR);
-        assert_eq!(gas::parse("1 TGas").unwrap(), ONE_TGAS)
+        assert_eq!(ONE_PARSED_NEAR, ONE_NEAR);
+
+    }
+
+    #[test]
+    fn const_parse_gas() {
+      assert_eq!(gas::parse("1 TGas").unwrap(), ONE_TGAS);
+      assert_eq!(ONE_PARSED_TGAS, ONE_TGAS);
     }
 }

--- a/crates/units/src/lib.rs
+++ b/crates/units/src/lib.rs
@@ -1,25 +1,23 @@
 pub use near_units_core::*;
 pub use near_units_macro::*;
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
     const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
     const ONE_TGAS: u128 = 1_000_000_000_000;
     const ONE_PARSED_NEAR: u128 = parse_near!("1 N");
-    const ONE_PARSED_TGAS: u128 = parse_gas! ("1 TGas");
+    const ONE_PARSED_TGAS: u128 = parse_gas!("1 TGas");
 
     #[test]
     fn const_parse_near() {
         assert_eq!(near::parse("1N").unwrap(), ONE_NEAR);
         assert_eq!(ONE_PARSED_NEAR, ONE_NEAR);
-
     }
 
     #[test]
     fn const_parse_gas() {
-      assert_eq!(gas::parse("1 TGas").unwrap(), ONE_TGAS);
-      assert_eq!(ONE_PARSED_TGAS, ONE_TGAS);
+        assert_eq!(gas::parse("1 TGas").unwrap(), ONE_TGAS);
+        assert_eq!(ONE_PARSED_TGAS, ONE_TGAS);
     }
 }


### PR DESCRIPTION
This hides the string parsing functions and incorporates the feedback from @ChaoticTempest.

Also changes the version of syn to make package compatible with current version of sdk.